### PR TITLE
Fix zero volatility fallback in VolatilityMetrics

### DIFF
--- a/test_volatility.py
+++ b/test_volatility.py
@@ -1,0 +1,19 @@
+import pytest
+from volatility import VolatilityMetrics, VolatilitySource
+
+def test_error_sigma_handles_zero():
+    vm = VolatilityMetrics(
+        sigma_1m=VolatilitySource(lambda: 0.0, "1m"),
+        sigma_1h=VolatilitySource(lambda: 0.02, "1h"),
+        sigma_24h=VolatilitySource(lambda: 0.04, "24h"),
+    )
+    assert vm.error_sigma() == 0.0
+
+
+def test_error_sigma_fallback_zero_from_1h():
+    vm = VolatilityMetrics(
+        sigma_1m=VolatilitySource(lambda: None, "1m"),
+        sigma_1h=VolatilitySource(lambda: 0.0, "1h"),
+        sigma_24h=VolatilitySource(lambda: 0.04, "24h"),
+    )
+    assert vm.error_sigma() == 0.0

--- a/volatility.py
+++ b/volatility.py
@@ -150,7 +150,11 @@ class VolatilityMetrics:
         We follow the spec: use 1‑minute vol if available, else fall back to 1‑h,
         then 24‑h, then 0.0.
         """
-        return self.get_1m() or self.get_1h() or self.get_24h() or 0.0
+        for getter in (self.get_1m, self.get_1h, self.get_24h):
+            val = getter()
+            if val is not None:
+                return val
+        return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +164,7 @@ class VolatilityMetrics:
 # These are optional examples; swap with your own endpoints as needed.
 
 def _binance_url(symbol: str, window: str) -> str:
-    return f"https://api.binance.com/api/v3/avgPrice?symbol={symbol}{window}"
+    return f"https://api.binance.com/api/v3/avgPrice?symbol={symbol}&window={window}"
 
 
 def fetch_hour_vol_from_binance(symbol="BTCUSDT") -> Optional[float]:


### PR DESCRIPTION
## Summary
- ensure error_sigma returns zero volatility instead of falling back to higher values
- correct Binance helper URL to include window query parameter
- add regression tests for zero-volatility cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689047dcff908329a397f79d57374dcd