### PR TITLE
Add latency metrics and GARCH pricing

### DIFF
--- a/btc24h_cache.py
+++ b/btc24h_cache.py
@@ -36,6 +36,11 @@ class BTC24hCache:
         with self._lock:
             return self._buffer[-1][1] if self._buffer else None
 
+    def get_latest(self):
+        """Return tuple ``(timestamp, spot)`` of the most recent sample."""
+        with self._lock:
+            return self._buffer[-1] if self._buffer else (None, None)
+
     def get_vol(self, window_sec: float):
         cutoff = time.time() - window_sec
         with self._lock:


### PR DESCRIPTION
## Summary
- Add `get_latest` helper to BTC cache so callers can measure staleness of price data
- Switch monitor from Black-Scholes to GARCH Monte-Carlo and display bid/mid/ask from the simulation
- Report latency for data freshness, Monte-Carlo pricing, API calls, and total loop time

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891041872548329a648df6d49ce5a24